### PR TITLE
improved accurate to Intl.DateTimeFormat

### DIFF
--- a/backend/weather.js
+++ b/backend/weather.js
@@ -38,9 +38,18 @@ fetch(apiUrl)
   .then((data) => {
     const tempUnit = unit === "imperial" ? "°F" : "°C";
     const now = new Date(); // Get current date and time
-    const localTime = new Date(
+    {
+      /* const localTime = new Date(
       (data.dt + data.timezone) * 1000
     ).toLocaleString();
+    */
+    }
+    // Use Intl.DateTimeFormat API
+    const localTime = new Intl.DateTimeFormat("en-US", {
+      timeZone: "UTC",
+      dateStyle: "full",
+      timeStyle: "short",
+    }).format(new Date((data.dt + data.timezone) * 1000)); // ✅ Fix applied
 
     console.log(chalk.cyan("@@@@@@@@@@@@@@@@@@@"));
     console.log(chalk.cyan("@ WEATHER PROGRAM @"));


### PR DESCRIPTION
**Problem:

- When using Intl.DateTimeFormat, the API expects a valid IANA time zone string (e.g., "Europe/London"). However, data.timezone from the API is a numeric offset in seconds, causing an "Invalid time zone specified: 0" error.
``` bash
const localTime = new Intl.DateTimeFormat("en-US", {
  timeZone: "UTC", // Use UTC as a base since the API gives offset in seconds
  dateStyle: "full",
  timeStyle: "short",
}).format(new Date((data.dt + data.timezone) * 1000));
```