### PR TITLE
fix(frontend): correct useWeather hook to handle city and geo queries

### DIFF
--- a/frontend/src/hooks/useWeather.js
+++ b/frontend/src/hooks/useWeather.js
@@ -5,19 +5,19 @@ import weatherApi from "../api/weatherApi";
  * Custom hook for fetching weather data using TanStack Query.
  * It automatically handles caching, refetching, and loading/error states.
  *
- * @param {string} city - The city to fetch weather for.
+ * @param {{city?: string; lat?: number; lon?: number}} params - The location parameters (city or coordinates).
  * @param {string} unit - The unit for temperature ('metric' or 'imperial').
  * @returns {import("@tanstack/react-query").UseQueryResult} The result object from useQuery.
  */
-export const useWeather = (city, unit = "metric") => {
+export const useWeather = (params, unit = "metric") => {
+  const { city, lat, lon } = params;
+
   return useQuery({
-    queryKey: ["weather", city, unit],
-    queryFn: () => weatherApi.getWeather(city, unit),
-    queryOptions: {
-      enabled: !!city, // Only run the query if a city is provided
-      staleTime: 1000 * 60 * 5, // Cache data for 5 minutes
-      retry: 1, // Retry failed requests once
-    },
+    queryKey: ["weather", params, unit],
+    queryFn: () => weatherApi.getWeather(params, unit),
+    enabled: !!(city || (lat && lon)), // Only run the query if location params are provided
+    staleTime: 1000 * 60 * 5, // Cache data for 5 minutes
+    retry: 1, // Retry failed requests once
   });
 };
 


### PR DESCRIPTION
The useWeather hook was incorrectly structured, leading to a bug where manual city searches would not trigger a UI update.

This was because the hook expected a string for the city parameter, but was being passed an object. Additionally, the React Query queryKey was not being constructed correctly to differentiate between city and coordinate-based searches.

This commit refactors the useWeather hook to:
- Accept a single 'params' object that contains either a city or lat/lon coordinates.
- Create a unique and stable queryKey based on the params object, ensuring queries are cached and refetched correctly.
- Correctly enable or disable the query based on the presence of valid location parameters.